### PR TITLE
Remove linked picture parent

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -41,6 +41,7 @@ function buildAutoBlocks(main) {
 }
 
 function linkPicture(picture) {
+  const oldParent = picture.parentNode;
   const nextSib = picture.parentNode.nextElementSibling;
   if (nextSib) {
     const a = nextSib.querySelector('a');
@@ -48,6 +49,7 @@ function linkPicture(picture) {
       a.innerHTML = '';
       a.className = '';
       a.appendChild(picture);
+      oldParent.remove();
     }
   }
 }


### PR DESCRIPTION
In the current implementation we're leaving an existing "p" that is empty. While it's not strictly needed, it makes it easier to implement selectors if we don't have to worry about an element that does nothing.

Part of #3

Test URLs:
- Before: https://main--eder-group--hlxsites.hlx.page/
- After: https://cleanup_linked_picture--eder-group--hlxsites.hlx.page/

Before: 
![image](https://user-images.githubusercontent.com/1713440/208955459-b78ea131-27fd-494d-9cf8-977345aafdf8.png)

After: 
![image](https://user-images.githubusercontent.com/1713440/208955620-77b92f6e-b132-4567-9376-717dd7ffbe22.png)
