### PR TITLE
Add fallback fonts to styles.css

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,6 +10,41 @@
  * governing permissions and limitations under the License.
  */
 
+/* fallback font for Glyphicons Halflings (normal - 400) */
+@font-face {
+  font-family: "glyphicons-halflings-normal-400-fallback";
+  size-adjust: 119.241%;
+  src: local("Arial");
+}
+
+/* fallback font for Flaticon (normal - 400) */
+@font-face {
+  font-family: "flaticon-normal-400-fallback";
+  size-adjust: 96.629%;
+  src: local("Arial");
+}
+
+/* fallback font for eder (normal - 400) */
+@font-face {
+  font-family: "eder-normal-400-fallback";
+  size-adjust: 91.379%;
+  src: local("Arial");
+}
+
+/* fallback font for Roboto (normal - 400) */
+@font-face {
+  font-family: "roboto-normal-400-fallback";
+  size-adjust: 99.569%;
+  src: local("Arial");
+}
+
+/* fallback font for Roboto (italic - 400) */
+@font-face {
+  font-family: "roboto-italic-400-fallback";
+  size-adjust: 97.629%;
+  src: local("Arial");
+}
+
  :root {
   /* colors */
   --link-color: #035fe6;


### PR DESCRIPTION
Used fallback font tool [0] to generate fallbacks for fonts found at [1]

[0] https://github.com/adobe/helix-font-fallback-extension#readme [1] https://www.eder-gmbh.de/unternehmen/geschaeftsfuehrung/

no noticeable change was encountered with the test site, was not able to really test the difference

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix 2nd task of [#1](https://github.com/hlxsites/eder-group/issues/1) 

Note: no noticeable change was encountered with the test site, was not able to really test the difference

Test URLs:
- Before: https://main--eder-group--hlxsites.hlx.page/
- After: https://issue-1--eder-group--hlxsites.hlx.page/
